### PR TITLE
style added in styles.css

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -7,3 +7,11 @@ body {
 html, body {
   height: 100%;
 }
+.mdc-text-field--filled  .mat-mdc-floating-label  {
+  width:calc(100% +  20px);
+
+}
+.mdc-text-field--outlined  .mat-mdc-floating-label  {
+  width:calc(100% - 20px) !important;
+
+}


### PR DESCRIPTION
label  text overlapping solution in material label  - I have added some CSS styles  to that material library label class.
Now no overlapping is  occurring 
